### PR TITLE
ci: Fix unrecognized 'secrets' in sonar workflow job condition (#47)

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,23 +10,29 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: read
 
 env:
   JAVA_VERSION: "21"
 
 jobs:
+  validate:
+    name: Validate run conditions
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - id: check
+        run: |
+          echo "should_run=${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && secrets.SONAR_TOKEN != '') }}" >> "$GITHUB_OUTPUT"
+
   sonar:
     name: Build and analyze
+    needs: validate
+    if: needs.validate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && 
-       github.event.pull_request.head.repo.fork == false && 
-       secrets.SONAR_TOKEN != '')
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,6 +18,7 @@ jobs:
   validate:
     name: Validate run conditions
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:


### PR DESCRIPTION
Move secret check to a separate validation job to avoid syntax errors in job-level conditions. This also ensures the pipeline skips Sonar analysis on PRs from forks or automation like Dependabot where secrets aren't available.